### PR TITLE
Incorrect rect-rect collision

### DIFF
--- a/vinage.js
+++ b/vinage.js
@@ -249,9 +249,8 @@ var vinage = (function(){
 			return pseudoClone;
 		}
 		function mod(dividend, divisor) {
-			if (!isFinite(divisor)) return divdend;
-			while (dividend < 0 || dividend >= divisor) dividend = (dividend + divisor) % divisor;
-			return dividend;
+			if (!isFinite(divisor)) return dividend;
+			return (dividend % divisor + divisor) % divisor;
 		}
 		function getDelta(coordOne, coordTwo, wrapLgt) {
 			var delta = mod(coordOne, wrapLgt) - mod(coordTwo, wrapLgt);
@@ -264,15 +263,10 @@ var vinage = (function(){
 		if (geomObjOne instanceof Rectangle) {
 			if (geomObjTwo instanceof Rectangle) {
 				if (geomObjOne.angle === geomObjTwo.angle) {
-					/*if (debug) {
-						console.log('collisions: world(' + this.width + ', ' + this.height + ') obj1(' + geomObjOne.center.x + ', ' + geomObjOne.center.y + ', ' + geomObjOne.width + ', ' + geomObjOne.height + ') obj2(' + geomObjTwo.center.x + ', ' + geomObjTwo.center.y + ', ' + geomObjTwo.width + ', ' + geomObjTwo.height + ')');
-					}*/
-
 					return (mod(geomObjTwo.center.x + geomObjTwo.width/2 - geomObjOne.center.x + geomObjOne.width/2, this.width) >= 0
 						&& mod(geomObjTwo.center.x - geomObjTwo.width/2 - geomObjOne.center.x + geomObjOne.width/2, this.width) <= geomObjOne.width
 						&& mod(geomObjTwo.center.y + geomObjTwo.height/2 - geomObjOne.center.y + geomObjOne.height/2, this.height) >= 0
 						&& mod(geomObjTwo.center.y - geomObjTwo.height/2 - geomObjOne.center.y + geomObjOne.height/2, this.height) <= geomObjOne.height);
-
 				} else {
 					var vertiTwo = makePseudoClones(geomObjTwo.vertices);
 					if (isFinite(this.width)) {

--- a/vinage.js
+++ b/vinage.js
@@ -96,17 +96,17 @@ var vinage = (function(){
 			return overlap(projOne, projTwo);
 		});
 	};
-	GeometricObject.prototype.circleCircle = function(circleOneX, circleOneY, circleOneRadius, circleTwoX, circleTwoY, circleTwoRadius) {
-		var deltaX = circleOneX - circleTwoX,
-			deltaY = circleOneY - circleTwoY,
-			deltaRadius = circleOneRadius + circleTwoRadius; // store the result
-		return deltaX*deltaX + deltaY*deltaY < deltaRadius*deltaRadius;
-	};
 	GeometricObject.prototype.aabbAabb = function(rectOneX, rectOneY, rectOneWidth, rectOneHeight, rectTwoX, rectTwoY, rectTwoWidth, rectTwoHeight) {
 		return ! (rectTwoX - rectTwoWidth/2 >= rectOneX + rectOneWidth/2
 		|| rectTwoX + rectTwoWidth/2 <= rectOneX - rectOneWidth/2
 		|| rectTwoY - rectTwoHeight/2 >= rectOneY + rectOneHeight/2
 		|| rectTwoY + rectTwoHeight/2 <= rectOneY - rectOneHeight/2);
+	};
+	GeometricObject.prototype.circleCircle = function(circleOneX, circleOneY, circleOneRadius, circleTwoX, circleTwoY, circleTwoRadius) {
+		var deltaX = circleOneX - circleTwoX,
+			deltaY = circleOneY - circleTwoY,
+			deltaRadius = circleOneRadius + circleTwoRadius; // store the result
+		return deltaX*deltaX + deltaY*deltaY < deltaRadius*deltaRadius;
 	};
 	GeometricObject.prototype.pointCircle = function(pointX, pointY, circleX, circleY, radius) {
 		var deltaX = circleX - pointX,
@@ -246,7 +246,7 @@ var vinage = (function(){
 			}
 		}
 	});
-	Rectangle.prototype.collide = function(geomObjOne, geomObjTwo) {
+	Rectangle.prototype.collide = function(geomObjOne, geomObjTwo, debug) {
 		function makePseudoClones(vertices) {
 			var pseudoClone = [];
 			vertices.forEach(function(vertex) {
@@ -255,7 +255,9 @@ var vinage = (function(){
 			return pseudoClone;
 		}
 		function mod(dividend, divisor) {
-			return (dividend%divisor + divisor) % divisor;
+			if (!isFinite(divisor)) return divdend;
+			while (dividend < 0 || dividend >= divisor) dividend = (dividend + divisor) % divisor;
+			return dividend;
 		}
 		function getDelta(coordOne, coordTwo, wrapLgt) {
 			var delta = mod(coordOne, wrapLgt) - mod(coordTwo, wrapLgt);
@@ -268,7 +270,15 @@ var vinage = (function(){
 		if (geomObjOne instanceof Rectangle) {
 			if (geomObjTwo instanceof Rectangle) {
 				if (geomObjOne.angle === geomObjTwo.angle) {
-					return this.aabbAabb(0, 0, geomObjOne.width, geomObjOne.height, isFinite(this.width) ? (geomObjTwo.center.x - geomObjOne.center.x + this.width)%this.width : geomObjTwo.center.x - geomObjOne.center.x, isFinite(this.height) ? (geomObjTwo.center.y - geomObjOne.center.y + this.height)%this.height : geomObjTwo.center.y - geomObjOne.center.y, geomObjTwo.width, geomObjTwo.height);
+					/*if (debug) {
+						console.log('collisions: world(' + this.width + ', ' + this.height + ') obj1(' + geomObjOne.center.x + ', ' + geomObjOne.center.y + ', ' + geomObjOne.width + ', ' + geomObjOne.height + ') obj2(' + geomObjTwo.center.x + ', ' + geomObjTwo.center.y + ', ' + geomObjTwo.width + ', ' + geomObjTwo.height + ')');
+					}*/
+
+					return (mod(geomObjTwo.center.x + geomObjTwo.width/2 - geomObjOne.center.x + geomObjOne.width/2, this.width) >= 0
+						&& mod(geomObjTwo.center.x - geomObjTwo.width/2 - geomObjOne.center.x + geomObjOne.width/2, this.width) <= geomObjOne.width
+						&& mod(geomObjTwo.center.y + geomObjTwo.height/2 - geomObjOne.center.y + geomObjOne.height/2, this.height) >= 0
+						&& mod(geomObjTwo.center.y - geomObjTwo.height/2 - geomObjOne.center.y + geomObjOne.height/2, this.height) <= geomObjOne.height);
+
 				} else {
 					var vertiTwo = makePseudoClones(geomObjTwo.vertices);
 					if (isFinite(this.width)) {
@@ -295,6 +305,7 @@ var vinage = (function(){
 			}
 		} else if (geomObjOne instanceof Circle) {
 			if (geomObjTwo instanceof Rectangle) {
+			
 				return this.circleObb(0, 0, geomObjOne.radius, isFinite(this.width) ? getDelta(geomObjOne.center.x, geomObjTwo.center.x, this.width) : geomObjOne.center.x - geomObjTwo.center.x, isFinite(this.height) ? getDelta(geomObjOne.center.y, geomObjTwo.center.y, this.height) : geomObjOne.center.y - geomObjTwo.center.y, geomObjTwo.width, geomObjTwo.height, geomObjTwo.angle);
 			} else if (geomObjTwo instanceof Circle) {
 				return this.circleCircle(0, 0, geomObjOne.radius, isFinite(this.width) ? getDelta(geomObjTwo.center.x, geomObjOne.center.x, this.width) : geomObjTwo.center.x - geomObjOne.center.x, isFinite(this.height) ? getDelta(geomObjTwo.center.y, geomObjOne.center.y, this.height) : geomObjTwo.center.y - geomObjOne.center.y, geomObjTwo.radius);

--- a/vinage.js
+++ b/vinage.js
@@ -96,12 +96,6 @@ var vinage = (function(){
 			return overlap(projOne, projTwo);
 		});
 	};
-	GeometricObject.prototype.aabbAabb = function(rectOneX, rectOneY, rectOneWidth, rectOneHeight, rectTwoX, rectTwoY, rectTwoWidth, rectTwoHeight) {
-		return ! (rectTwoX - rectTwoWidth/2 >= rectOneX + rectOneWidth/2
-		|| rectTwoX + rectTwoWidth/2 <= rectOneX - rectOneWidth/2
-		|| rectTwoY - rectTwoHeight/2 >= rectOneY + rectOneHeight/2
-		|| rectTwoY + rectTwoHeight/2 <= rectOneY - rectOneHeight/2);
-	};
 	GeometricObject.prototype.circleCircle = function(circleOneX, circleOneY, circleOneRadius, circleTwoX, circleTwoY, circleTwoRadius) {
 		var deltaX = circleOneX - circleTwoX,
 			deltaY = circleOneY - circleTwoY,


### PR DESCRIPTION
When calling `universe.collide(geomObj1, geomObj2)` and both geometric objects are rectangles and have the same angle, an erroneous function was used. It failed when wrapping around the universe.
The changed collision detection works like:
1. move both objects, so that the first object's top-left corner is located at (0, 0)
2. wrap (if the parents width and height are finite) outer-most points (top, left, bottom, right)
3. compare wrapped points to check whether the objects overlap/intersect/touch
4. return true or false :nerd_face: 

In order to make it work, I also "improved" the `mod` function used by the collision detection methods.
It supports applying modulo to negative values and avoid wrapping if the universe isn't finite, like
```
mod(20, 3);
// 2, because 20 / 3 = 6 (remainder 2)
mod(-20, 3);
// 1, because we add 3 to -20 until it is positive and apply modulo
// like so: (-20 + 6 * 3) % 3 = 1 % 3 = 1
mod(20, Math.Infinity);
// 20 (no wrapping because the divisor is not finite)
```
It refers to this [bug](https://github.com/KordonBleu/jumpsuit/projects/1#card-1913110)

Cheers !